### PR TITLE
Hotfix: broken link GitHub access request form

### DIFF
--- a/docs/github/getting-access-to-github-org-and-team.md
+++ b/docs/github/getting-access-to-github-org-and-team.md
@@ -8,8 +8,6 @@ sidebar_custom_props:
 For our GitHub-based work, you will first be invited to our GitHub organisation. Once you’ve joined, you can request access to the project team.
 
 ## Step 1 – Request an Invitation
-> ⚠️ **Important:** The access request form is only available until **21.08.2025**.  
-> Please submit your request before this date — late requests cannot be processed.
 
 1. Open the form:  
    [📄 GitHub Access Request Form](https://n8n.pybay.de/form/506dd53a-e175-4d10-9bd4-901b621f4d9a)


### PR DESCRIPTION
Due to the free trial of n8n cloud instance is expiring tomorrow night i did:
- set up an n8n self hosted instance on a private vps available under n8n.pybay.de
- fix the link to the "request access to github org" form
