### PR TITLE
[DOCS] Process - request a new shared component

### DIFF
--- a/docs/frontend/shared-components/developing.md
+++ b/docs/frontend/shared-components/developing.md
@@ -7,6 +7,7 @@ sidebar_custom_props:
 # Contribute to the shared-components
 
 This is a step-by-step guide if you need to change some components or add new ones from the shared-components library.
+> 💡 If you have **not already requested a new component**, please first follow the [Request a new shared component](./request-shared-component.md) guide before starting development.
 
 ## 1. Setup shared-components
 

--- a/docs/frontend/shared-components/request-shared-component.md
+++ b/docs/frontend/shared-components/request-shared-component.md
@@ -43,4 +43,4 @@ This ensures a consistent process across all teams and makes sure every request 
 If you encounter problems with the process:
 - Reach out to **Alexander Jablonowski** (board admin)  
 - Or contact **Team 15** (shared-components maintainers)
-- Simon Dietrich for form / automation (n8n) issues
+- Or contact **Simon Dietrich** for form / automation (n8n) issues

--- a/docs/frontend/shared-components/request-shared-component.md
+++ b/docs/frontend/shared-components/request-shared-component.md
@@ -42,5 +42,4 @@ This ensures a consistent process across all teams and makes sure every request 
 
 If you encounter problems with the process:
 - Reach out to **Alexander Jablonowski** (board admin)  
-- Or contact **Team 15** (shared-components maintainers)
 - Or contact **Simon Dietrich** for form / automation (n8n) issues

--- a/docs/frontend/shared-components/request-shared-component.md
+++ b/docs/frontend/shared-components/request-shared-component.md
@@ -1,0 +1,46 @@
+---
+sidebar_position: 3
+sidebar_custom_props:
+  myEmoji: 📝
+---
+
+# Request a new shared-component
+
+All new shared components should be requested via our shared form.  
+This ensures a consistent process across all teams and makes sure every request is tracked in one place.
+
+## Process Overview
+
+1. **Submit a request**  
+   Fill out the request form: [➡️ Request Form](https://n8n.pybay.de/form/4d538dde-de36-402d-91d3-8db3da251005)  
+   Please Provide:
+   - Requesting Team
+   - Contact Person
+   - Contact Email
+   - Component Name
+   - Component Description
+   - Link to sample (optional)
+
+2. **Issue creation**  
+   An issue is automatically created in the [shared-components GitHub repo](https://github.com/Agile-Software-Engineering-25/shared-components/issues).  
+   The issue is also added to the shared Kanban board: [Kanban Board](https://github.com/orgs/Agile-Software-Engineering-25/projects/4/views/1)  
+
+3. **Design team review**  
+   The design team first reviews the request to ensure visual and UX consistency.  
+   They may update the issue with design guidelines or mockups.
+
+4. **Implementation**  
+   Once the design is approved, the requester (your team) is expected to implement the component in the [`shared-components` library](https://github.com/Agile-Software-Engineering-25/shared-components).  
+   - Follow the [development guide](./developing.md) to set up your local environment.  
+   - Open a Pull Request linking the issue.  
+
+5. **Tracking & updates**  
+   The Kanban board is managed by **Alexander Jablonowski**.  
+   You can always check it to see the status of your request and ongoing work.
+
+## Support
+
+If you encounter problems with the process:
+- Reach out to **Alexander Jablonowski** (board admin)  
+- Or contact **Team 15** (shared-components maintainers)
+- Simon Dietrich for form / automation (n8n) issues

--- a/docs/frontend/shared-components/shared-components.md
+++ b/docs/frontend/shared-components/shared-components.md
@@ -6,18 +6,24 @@ sidebar_custom_props:
 
 # About
 
-shared-components is a library intended for use by all SAU frontends. It contains reusable components and a custom common theme called `joy`.
+The **shared-components library** is the central place for reusable UI components and a common `joy` theme.  
+It is used by **all SAU frontend teams** to ensure a consistent look & feel and to avoid duplicate work.
 
-If you think a component you created might be useful for other teams, add it to the library. Before creating a new component, check if someone has already created what you need.
+Before creating a new component in your project, always check if it already exists here.  
+If not, you can request a new component so it becomes available for everyone (see [Request a new shared component](./request-shared-component.md)).
 
-# ⚠️Disclaimer⚠️
+# ⚠️ Disclaimer ⚠️
 
-All Components and the joy theme in this repository are **ONLY** examples and **NEED** to be exchanged with real ones. Expect them to be deleted or massively changed.
+All components and the `joy` theme in this repository are currently **examples**.  
+They **will be replaced or heavily changed** once real production components are introduced.
 
 # Installation & Usage
 
-See the [frontend-template-repository](https://github.com/Agile-Software-Engineering-25/frontend-template) and the [shared-components-repository](https://github.com/Agile-Software-Engineering-25/shared-components) for installation and usage.
+For setup and usage examples, see:  
+- [Frontend template repository](https://github.com/Agile-Software-Engineering-25/frontend-template)  
+- [Shared components repository](https://github.com/Agile-Software-Engineering-25/shared-components)  
+
 
 # Support
 
-If you encounter any problems reach out to Alexander Jablonowski or Team 15.
+If you encounter any problems reach out to **Alexander Jablonowski** or **Team 15**.

--- a/docs/frontend/shared-components/shared-components.md
+++ b/docs/frontend/shared-components/shared-components.md
@@ -26,4 +26,4 @@ For setup and usage examples, see:
 
 # Support
 
-If you encounter any problems reach out to **Alexander Jablonowski** or **Team 15**.
+If you encounter any problems reach out to **Alexander Jablonowski**.


### PR DESCRIPTION
### ✨ What’s new
- Added a new documentation page: **`request-shared-component.md`**
  - Explains the **request automation process** for new shared components  
  - Provides a **process overview** (form → GitHub issue → Kanban board → design → implementation)  
- Updated **`shared-components.md`**  
  - Clearer introduction (why the library exists, used by all teams)  
  - Added link to the request guide  
- Updated **`developing.md`**  
  - Added a note: developers should submit a request first **if they have not already done so**  

### 📚 Why
Previously, there was no clear guidance for developers on how to propose or request new shared components.  
This PR introduces a **consistent process for all 15 teams** using the n8n form, GitHub issues, and Kanban tracking, and clarifies when to request vs. when to start developing.  

### 🔗 References
- Request form: [https://n8n.pybay.de/form/4d538dde-de36-402d-91d3-8db3da251005](https://n8n.pybay.de/form/4d538dde-de36-402d-91d3-8db3da251005)  
- Issues: [shared-components repo](https://github.com/Agile-Software-Engineering-25/shared-components/issues)  
- Kanban board: [GitHub Project Board](https://github.com/orgs/Agile-Software-Engineering-25/projects/4/views/1)  

### ✅ Next steps
- Share the new process with all teams  
