### PR TITLE
docs: add frontend deployment guide and category file

### DIFF
--- a/docs/deployment/frontend/_category_.json
+++ b/docs/deployment/frontend/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Frontend",
+  "position": 2,
+  "link": {
+    "type": "generated-index"
+  }
+}

--- a/docs/deployment/frontend/intro.md
+++ b/docs/deployment/frontend/intro.md
@@ -1,0 +1,162 @@
+# 🚀 Microfrontend Deployment Guide
+
+---
+
+Deploying your **microfrontends** is simpler than deploying backend services.  
+You don’t need to deal with Rancher or Kubernetes — all you need are your **MinIO credentials**.
+
+👉 Your Product Owner should have access to these credentials.  
+If not, please reach out to **Janne Keipert** (📧 jabbekeipert@gmail.com).
+
+---
+
+## 📦 Deployment Process
+
+---
+
+Your task is straightforward:  
+**Upload your build artifacts to MinIO.**
+
+We’ve prepared a **MinIO server** and a **bucket** specifically for this purpose.  
+Below is a ready-to-use **GitHub Actions workflow** that:
+
+1. Builds your application (`npm run build`)
+2. Uploads the build artifacts to your MinIO bucket
+
+---
+
+## 🛠 GitHub Actions Workflow
+
+---
+
+```yaml
+name: Build and Deploy to MinIO
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Clear shared components dir
+        run: |
+          rm -rf ./shared-components/*
+          rm -rf ./shared-components/.[!.]* ./shared-components/..?* || true
+
+      - name: Setup Shared Components
+        run: npm run init
+
+      - name: Build application
+        run: npm run build
+        env:
+          VITE_BACKEND_BASE_URL: ${{ vars.VITE_BACKEND_BASE_URL }}
+
+      - name: Setup MinIO Client
+        run: |
+          curl https://dl.min.io/aistor/mc/release/linux-amd64/mc \
+            --create-dirs \
+            -o $HOME/minio-binaries/mc
+          chmod +x $HOME/minio-binaries/mc
+          export PATH=$PATH:$HOME/minio-binaries/
+
+      - name: Configure MinIO Client
+        run: |
+          $HOME/minio-binaries/mc alias set minio \
+            ${{ secrets.MINIO_ENDPOINT }} \
+            ${{ secrets.MINIO_ACCESS_KEY }} \
+            ${{ secrets.MINIO_SECRET_KEY }}
+
+      - name: Clear existing files in bucket
+        run: |
+          $HOME/minio-binaries/mc rm --recursive --force minio/${{ secrets.BUCKET_NAME }} || echo "No existing files to remove"
+
+      - name: Upload dist files to MinIO
+        run: |
+          $HOME/minio-binaries/mc cp --recursive dist/ minio/${{ secrets.BUCKET_NAME }}
+
+      - name: Set bucket to public (optional)
+        run: |
+          $HOME/minio-binaries/mc anonymous set public minio/${{ secrets.BUCKET_NAME }} || echo "Could not set public access - check permissions"
+
+      - name: List uploaded files
+        run: |
+          echo "Files uploaded to MinIO:"
+          $HOME/minio-binaries/mc ls --recursive minio/${{ secrets.BUCKET_NAME }}
+
+      - name: Deploy Summary
+        run: |
+          echo "🚀 Deployment completed successfully!"
+          echo "📦 Files uploaded from ./dist to minio/${{secrets.BUCKET_NAME}} bucket"
+          echo "🌐 Application should be available at your MinIO endpoint"
+```
+
+---
+
+## 🔑 Required Repository Secrets
+
+| Secret Name             | Description                                                                                                |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `MINIO_ENDPOINT`        | MinIO server endpoint (e.g. `https://minio.sau-portal.de`)                                                 |
+| `MINIO_ACCESS_KEY`      | Access key (username) for MinIO                                                                            |
+| `MINIO_SECRET_KEY`      | Secret key (password) for MinIO                                                                            |
+| `BUCKET_NAME`           | Name of the bucket where build artifacts will be uploaded (this is your Team number (e.g. `ase-12`))       |
+| `VITE_BACKEND_BASE_URL` | Backend base URL used in your app (see [Using env variables in Vite](https://vite.dev/guide/env-and-mode)) |
+
+---
+
+## 🧪 Testing the Workflow
+
+If you want the workflow to run for **every branch push**, update this section:
+
+```yaml
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+```
+
+⬇ Change it to:
+
+```yaml
+on:
+  push:
+    branches: ["**"]
+  workflow_dispatch:
+```
+
+---
+
+## 🌐 Accessing Your Deployed App
+
+Once deployed, your artifacts will be available at:
+
+```
+https://sau-portal.de/api/[BUCKET_NAME]/singleSpa.js
+```
+
+To integrate your microfrontend into the **Root UI**, please contact:  
+📧 **Janne Keipert** (jabbekeipert@gmail.com)
+
+---
+
+## 📝 Notes
+
+- ✅ Deployment is **fully automated** once set up
+- ⚠️ Be cautious everything you upload into your bucket will be **public** — only upload non sensitive files
+- 🐛 If you spot any errors or issues, let me know

--- a/yarn.lock
+++ b/yarn.lock
@@ -4368,11 +4368,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"


### PR DESCRIPTION
This pull request adds new documentation for deploying frontend microfrontends using MinIO, including a detailed deployment guide and GitHub Actions workflow. It introduces a new frontend documentation category and provides step-by-step instructions for building, deploying, and accessing microfrontend applications.

Documentation improvements:

* Added a new `_category_.json` file to create a "Frontend" section in the deployment documentation, making it easier to find frontend deployment guides.
* Added a comprehensive `intro.md` guide for deploying microfrontends, including:
  * An overview of the deployment process and required credentials.
  * A ready-to-use GitHub Actions workflow for building and deploying to MinIO.
  * Instructions for required repository secrets and how to test and access deployments.
  * Notes and contact information for further support.